### PR TITLE
Translate Docker Worker payload.features.{bulkLog,localLiveLog} to Generic Worker

### DIFF
--- a/d2g.go
+++ b/d2g.go
@@ -1,6 +1,6 @@
-//go:generate /bin/bash -c "echo -e 'file://schemas/docker_worker_payload.yml\nfile://schemas/generic_worker_payload.yml\nfile://schemas/test_suites.yml' | jsonschema2go -o d2g_test > generated_types_test.go && gofmt -w generated_types_test.go"
-//go:generate /bin/bash -c "echo 'file://schemas/docker_worker_payload.yml' | jsonschema2go -o dockerworker > dockerworker/generated_types.go && gofmt -w dockerworker/generated_types.go"
-//go:generate /bin/bash -c "echo 'file://schemas/generic_worker_payload.yml' | jsonschema2go -o genericworker > genericworker/generated_types.go && gofmt -w genericworker/generated_types.go"
+//go:generate /bin/bash -c "echo -e 'file://schemas/docker_worker_payload.yml\nfile://schemas/generic_worker_payload.yml\nfile://schemas/test_suites.yml' | jsonschema2go -d -o d2g_test > generated_types_test.go && gofmt -w generated_types_test.go"
+//go:generate /bin/bash -c "echo 'file://schemas/docker_worker_payload.yml' | jsonschema2go -d -o dockerworker > dockerworker/generated_types.go && gofmt -w dockerworker/generated_types.go"
+//go:generate /bin/bash -c "echo 'file://schemas/generic_worker_payload.yml' | jsonschema2go -d -o genericworker > genericworker/generated_types.go && gofmt -w genericworker/generated_types.go"
 
 package d2g
 
@@ -212,6 +212,8 @@ func setFeatures(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *generic
 	gwPayload.Features.ChainOfTrust = dwPayload.Features.ChainOfTrust
 	gwPayload.Features.TaskclusterProxy = dwPayload.Features.TaskclusterProxy
 	gwPayload.Features.Interactive = dwPayload.Features.Interactive
+	gwPayload.Features.LiveLog = dwPayload.Features.LocalLiveLog
+	gwPayload.Features.BackingLog = dwPayload.Features.BulkLog
 }
 
 func setArtifacts(dwPayload *dockerworker.DockerWorkerPayload, gwPayload *genericworker.GenericWorkerPayload) {

--- a/d2g_test.go
+++ b/d2g_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"unsafe"
 
+	"github.com/mcuadros/go-defaults"
 	"github.com/taskcluster/d2g"
 	"github.com/taskcluster/d2g/dockerworker"
 	"github.com/xeipuuv/gojsonschema"
@@ -47,6 +48,7 @@ func testSuite(schemaLoader gojsonschema.JSONLoader, path string) func(t *testin
 		validateTestSuite(t, schemaLoader, path)
 		// Iterate through test cases in the test suite, and execute a subtest for each test case
 		var d D2GTestCases
+		defaults.SetDefaults(&d)
 		unmarshalYAML(t, &d, path)
 		for _, tc := range d.TestSuite.Tests {
 			t.Run(

--- a/dockerworker/generated_types.go
+++ b/dockerworker/generated_types.go
@@ -28,7 +28,7 @@ type (
 		// Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
 		//
 		// Default:    false
-		Privileged bool `json:"privileged,omitempty"`
+		Privileged bool `json:"privileged" default:"false"`
 	}
 
 	// Allows devices from the host system to be attached to a task container similar to using `--device` in docker.
@@ -107,7 +107,7 @@ type (
 		// Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
 		//
 		// Default:    "public/logs/live.log"
-		Log string `json:"log,omitempty"`
+		Log string `json:"log" default:"public/logs/live.log"`
 
 		// Maximum time the task container can run in seconds.
 		//
@@ -140,30 +140,47 @@ type (
 	FeatureFlags struct {
 
 		// This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
-		AllowPtrace bool `json:"allowPtrace,omitempty"`
+		//
+		// Default:    false
+		AllowPtrace bool `json:"allowPtrace" default:"false"`
 
-		Artifacts bool `json:"artifacts,omitempty"`
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
 
 		// Useful if live logging is not interesting but the overalllog is later on
-		BulkLog bool `json:"bulkLog,omitempty"`
+		//
+		// Default:    true
+		BulkLog bool `json:"bulkLog" default:"true"`
 
 		// Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		//
+		// Default:    false
+		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
 		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		Dind bool `json:"dind,omitempty"`
+		//
+		// Default:    false
+		Dind bool `json:"dind" default:"false"`
 
 		// Uploads docker images as artifacts
-		DockerSave bool `json:"dockerSave,omitempty"`
+		//
+		// Default:    false
+		DockerSave bool `json:"dockerSave" default:"false"`
 
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
-		Interactive bool `json:"interactive,omitempty"`
+		//
+		// Default:    false
+		Interactive bool `json:"interactive" default:"false"`
 
 		// Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
-		LocalLiveLog bool `json:"localLiveLog,omitempty"`
+		//
+		// Default:    true
+		LocalLiveLog bool `json:"localLiveLog" default:"true"`
 
 		// The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		//
+		// Default:    false
+		TaskclusterProxy bool `json:"taskclusterProxy" default:"false"`
 	}
 
 	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace

--- a/generated_types_test.go
+++ b/generated_types_test.go
@@ -304,7 +304,7 @@ type (
 		// Allows a task to run in a privileged container, similar to running docker with `--privileged`.  This only works for worker-types configured to enable it.
 		//
 		// Default:    false
-		Privileged bool `json:"privileged,omitempty"`
+		Privileged bool `json:"privileged" default:"false"`
 	}
 
 	// Set of capabilities that must be enabled or made available to the task container Example: ```{ "capabilities": { "privileged": true }```
@@ -322,7 +322,7 @@ type (
 		// Default:    false
 		//
 		// See https://community-tc.services.mozilla.com/schemas/docker-worker/v1/payload.json#/properties/capabilities/properties/privileged
-		Privileged bool `json:"privileged,omitempty"`
+		Privileged bool `json:"privileged" default:"false"`
 	}
 
 	// Static d2g input/output test cases. Contains pairs of Docker Worker payload
@@ -458,7 +458,7 @@ type (
 		// Specifies a custom name for the livelog artifact. Note that this is also used in determining the name of the backing log artifact name. Backing log artifact name matches livelog artifact name with `_backing` appended, prior to the file extension (if present). For example, `apple/banana.log.txt` results in livelog artifact `apple/banana.log.txt` and backing log artifact `apple/banana.log_backing.txt`. Defaults to `public/logs/live.log`.
 		//
 		// Default:    "public/logs/live.log"
-		Log string `json:"log,omitempty"`
+		Log string `json:"log" default:"public/logs/live.log"`
 
 		// Maximum time the task container can run in seconds.
 		//
@@ -540,7 +540,7 @@ type (
 		// Default:    "public/logs/live.log"
 		//
 		// See https://community-tc.services.mozilla.com/schemas/docker-worker/v1/payload.json#/properties/log
-		Log string `json:"log,omitempty"`
+		Log string `json:"log" default:"public/logs/live.log"`
 
 		// Maximum time the task container can run in seconds.
 		//
@@ -669,30 +669,47 @@ type (
 	FeatureFlags struct {
 
 		// This allows you to use the Linux ptrace functionality inside the container; it is otherwise disallowed by Docker's security policy.
-		AllowPtrace bool `json:"allowPtrace,omitempty"`
+		//
+		// Default:    false
+		AllowPtrace bool `json:"allowPtrace" default:"false"`
 
-		Artifacts bool `json:"artifacts,omitempty"`
+		// Default:    true
+		Artifacts bool `json:"artifacts" default:"true"`
 
 		// Useful if live logging is not interesting but the overalllog is later on
-		BulkLog bool `json:"bulkLog,omitempty"`
+		//
+		// Default:    true
+		BulkLog bool `json:"bulkLog" default:"true"`
 
 		// Artifacts named chain-of-trust.json and chain-of-trust.json.sig should be generated which will include information for downstream tasks to build a level of trust for the artifacts produced by the task and the environment it ran in.
-		ChainOfTrust bool `json:"chainOfTrust,omitempty"`
+		//
+		// Default:    false
+		ChainOfTrust bool `json:"chainOfTrust" default:"false"`
 
 		// Runs docker-in-docker and binds `/var/run/docker.sock` into the container. Doesn't allow privileged mode, capabilities or host volume mounts.
-		Dind bool `json:"dind,omitempty"`
+		//
+		// Default:    false
+		Dind bool `json:"dind" default:"false"`
 
 		// Uploads docker images as artifacts
-		DockerSave bool `json:"dockerSave,omitempty"`
+		//
+		// Default:    false
+		DockerSave bool `json:"dockerSave" default:"false"`
 
 		// This allows you to interactively run commands inside the container and attaches you to the stdin/stdout/stderr over a websocket. Can be used for SSH-like access to docker containers.
-		Interactive bool `json:"interactive,omitempty"`
+		//
+		// Default:    false
+		Interactive bool `json:"interactive" default:"false"`
 
 		// Logs are stored on the worker during the duration of tasks and available via http chunked streaming then uploaded to s3
-		LocalLiveLog bool `json:"localLiveLog,omitempty"`
+		//
+		// Default:    true
+		LocalLiveLog bool `json:"localLiveLog" default:"true"`
 
 		// The auth proxy allows making requests to taskcluster/queue and taskcluster/scheduler directly from your task with the same scopes as set in the task. This can be used to make api calls via the [client](https://github.com/taskcluster/taskcluster-client) CURL, etc... Without embedding credentials in the task.
-		TaskclusterProxy bool `json:"taskclusterProxy,omitempty"`
+		//
+		// Default:    false
+		TaskclusterProxy bool `json:"taskclusterProxy" default:"false"`
 	}
 
 	// Feature flags enable additional functionality.
@@ -706,7 +723,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -735,7 +752,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -809,7 +826,7 @@ type (
 		// Default:    true
 		//
 		// See https://community-tc.services.mozilla.com/schemas/generic-worker/multiuser_posix.json#/properties/features/properties/backingLog
-		BackingLog bool `json:"backingLog,omitempty"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -844,7 +861,7 @@ type (
 		// Default:    true
 		//
 		// See https://community-tc.services.mozilla.com/schemas/generic-worker/multiuser_posix.json#/properties/features/properties/liveLog
-		LiveLog bool `json:"liveLog,omitempty"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -1036,7 +1053,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -1044,7 +1061,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Configuration for task logs.
@@ -1062,7 +1079,7 @@ type (
 		// Default:    "public/logs/live_backing.log"
 		//
 		// See https://community-tc.services.mozilla.com/schemas/generic-worker/multiuser_posix.json#/properties/logs/properties/backing
-		Backing string `json:"backing,omitempty"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -1072,7 +1089,7 @@ type (
 		// Default:    "public/logs/live.log"
 		//
 		// See https://community-tc.services.mozilla.com/schemas/generic-worker/multiuser_posix.json#/properties/logs/properties/live
-		Live string `json:"live,omitempty"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Image to use for the task.  Images can be specified as an image tag as used by a docker registry, or as an object declaring type and name/namespace

--- a/genericworker/generated_types.go
+++ b/genericworker/generated_types.go
@@ -165,7 +165,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		BackingLog bool `json:"backingLog,omitempty"`
+		BackingLog bool `json:"backingLog" default:"true"`
 
 		// Artifacts named `public/chain-of-trust.json` and
 		// `public/chain-of-trust.json.sig` should be generated which will
@@ -194,7 +194,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    true
-		LiveLog bool `json:"liveLog,omitempty"`
+		LiveLog bool `json:"liveLog" default:"true"`
 
 		// The taskcluster proxy provides an easy and safe way to make authenticated
 		// taskcluster requests within the scope(s) of a particular task. See
@@ -335,7 +335,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live_backing.log"
-		Backing string `json:"backing,omitempty"`
+		Backing string `json:"backing" default:"public/logs/live_backing.log"`
 
 		// Specifies a custom name for the live log artifact.
 		// This is only used if `features.liveLog` is `true`.
@@ -343,7 +343,7 @@ type (
 		// Since: generic-worker 48.2.0
 		//
 		// Default:    "public/logs/live.log"
-		Live string `json:"live,omitempty"`
+		Live string `json:"live" default:"public/logs/live.log"`
 	}
 
 	// Byte-for-byte literal inline content of file/archive, up to 64KB in size.

--- a/schemas/docker_worker_payload.yml
+++ b/schemas/docker_worker_payload.yml
@@ -220,12 +220,14 @@ properties:
         description: >-
           Logs are stored on the worker during the duration of tasks and
           available via http chunked streaming then uploaded to s3
+        default: true
       bulkLog:
         type: boolean
         title: Bulk upload the task log into a single artifact
         description: >-
           Useful if live logging is not interesting but the overalllog is later
           on
+        default: true
       taskclusterProxy:
         type: boolean
         title: Taskcluster auth proxy service
@@ -235,10 +237,12 @@ properties:
           set in the task. This can be used to make api calls via the
           [client](https://github.com/taskcluster/taskcluster-client) CURL,
           etc... Without embedding credentials in the task.
+        default: false
       artifacts:
         type: boolean
         title: Artifact uploads
         description: ''
+        default: true
       dind:
         type: boolean
         title: Docker in Docker
@@ -246,10 +250,12 @@ properties:
           Runs docker-in-docker and binds `/var/run/docker.sock` into the
           container. Doesn't allow privileged mode, capabilities or host volume
           mounts.
+        default: false
       dockerSave:
         type: boolean
         title: Docker save
         description: Uploads docker images as artifacts
+        default: false
       interactive:
         type: boolean
         title: Docker Exec Interactive
@@ -257,12 +263,14 @@ properties:
           This allows you to interactively run commands inside the container and
           attaches you to the stdin/stdout/stderr over a websocket. Can be used
           for SSH-like access to docker containers.
+        default: false
       allowPtrace:
         type: boolean
         title: Allow ptrace within the container
         description: >-
           This allows you to use the Linux ptrace functionality inside the
           container; it is otherwise disallowed by Docker's security policy.
+        default: false
       chainOfTrust:
         type: boolean
         title: Enable generation of ed25519-signed Chain of Trust artifacts
@@ -271,6 +279,7 @@ properties:
           be generated which will include information for downstream tasks to
           build a level of trust for the artifacts produced by the task and the
           environment it ran in.
+        default: false
     required: []
     additionalProperties: false
 additionalProperties: false


### PR DESCRIPTION
Note, `go generate` for this project now depends on the updated `jsonschema2go` cli tool from https://github.com/taskcluster/taskcluster/pull/6210.

* Fixes https://github.com/taskcluster/taskcluster/issues/5984
* Fixes https://github.com/taskcluster/taskcluster/issues/5985