### PR TITLE
Avoid persisting podman container image when not needed

### DIFF
--- a/testdata/testcases/devices_tests.yml
+++ b/testdata/testcases/devices_tests.yml
@@ -19,19 +19,13 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --name taskcontainer
+              podman run --rm
               -v /dev/shm:/dev/shm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               ubuntu 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
 
     - name: KVM
@@ -51,17 +45,11 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --name taskcontainer
+              podman run --rm
               -v /dev/kvm:/dev/kvm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               ubuntu 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600

--- a/testdata/testcases/docker_image_tests.yml
+++ b/testdata/testcases/docker_image_tests.yml
@@ -15,18 +15,12 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               ubuntu 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
 
     - name: NamedDockerImage
@@ -44,18 +38,12 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               ubuntu 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
 
     - name: IndexedDockerImage
@@ -78,18 +66,12 @@ testSuite:
 
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
         features:
           taskclusterProxy: true
@@ -118,18 +100,12 @@ testSuite:
 
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
         features:
           taskclusterProxy: true
@@ -158,18 +134,12 @@ testSuite:
 
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         maxRunTime: 3600
         features:
           taskclusterProxy: true
@@ -192,18 +162,12 @@ testSuite:
             - >-
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         mounts:
           - content:
               artifact: public/test/path
@@ -233,18 +197,12 @@ testSuite:
 
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         mounts:
           - content:
               artifact: public/test/path.lz4
@@ -274,18 +232,12 @@ testSuite:
 
               IMAGE_NAME=$(podman load -i path | sed -n 's/.*: //p')
 
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               "${IMAGE_NAME}" 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         mounts:
           - content:
               artifact: public/test/path.zst

--- a/testdata/testcases/no_artifacts_test.yml
+++ b/testdata/testcases/no_artifacts_test.yml
@@ -23,18 +23,12 @@ testSuite:
           - - bash
             - '-cx'
             - >-
-              podman run --name taskcontainer
+              podman run --rm
               -e "RUN_ID=${RUN_ID}" -e
               "TASKCLUSTER_ROOT_URL=${TASKCLUSTER_ROOT_URL}" -e
               "TASKCLUSTER_WORKER_LOCATION=${TASKCLUSTER_WORKER_LOCATION}" -e
               "TASK_ID=${TASK_ID}"
               ubuntu 'echo "Hello world"'
-
-              exit_code=$?
-
-              podman rm taskcontainer
-
-              exit "${exit_code}"
         features:
           backingLog: false
           liveLog: false


### PR DESCRIPTION
This is a simplification to generated payload when no artifacts need extracting from the podman container and the container image is not saved with a podman save command. In these cases, there is no need to persist the container image, preserve the exit code, delete the image, and then exit with the exit code.