### PR TITLE
Run go generate in CI

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -40,7 +40,10 @@ tasks:
               cd d2g
               git -c advice.detachedHead=false checkout '${head_rev}'
 
+              go install github.com/taskcluster/taskcluster/v51/tools/jsonschema2go/jsonschema2go@latest
+              go generate ./...
               go mod tidy
+
               git status
               test $(git status --porcelain | wc -l) == 0
 


### PR DESCRIPTION
The CI will fail until we have released taskcluster v51, since it depends on https://github.com/taskcluster/taskcluster/pull/6253 which is not yet released.